### PR TITLE
KM-14522 Improve reconnection mechanism when server reboots / disappears

### DIFF
--- a/Sources/TunnelKitOpenVPNCore/OpenVPNError.swift
+++ b/Sources/TunnelKitOpenVPNCore/OpenVPNError.swift
@@ -37,8 +37,8 @@
 import Foundation
 
 /// The possible errors raised/thrown during `OpenVPNSession` operation.
-public enum OpenVPNError: String, Error {
-    
+public enum OpenVPNError: String, CustomNSError {
+
     /// The negotiation timed out.
     case negotiationTimeout
     
@@ -66,9 +66,6 @@ public enum OpenVPNError: String, Error {
     /// A write operation failed at the link layer (e.g. network unreachable).
     case failedLinkWrite
     
-    /// The server couldn't ping back before timeout.
-    case pingTimeout
-    
     /// The session reached a stale state and can't be recovered.
     case staleSession
 
@@ -80,4 +77,7 @@ public enum OpenVPNError: String, Error {
 
     /// Remote server shut down (--explicit-exit-notify).
     case serverShutdown
+
+    /// Connectivity check failed.
+    case connectivityCheckFailed
 }


### PR DESCRIPTION
## Summary

- Replaces the old OpenVPN keepalive ping mechanism (inbound packet timestamp tracking + `pingTimeout` error) with an active TCP connectivity check through the tunnel
- Introduces a `tcpPingHandler` on `OpenVPNSession` that tests end-to-end tunnel connectivity by creating a TCP connection through the tunnel to the server's port 443
- Terminates the tunnel after 5 consecutive TCP ping failures via a new `connectivityCheckFailed` error, enabling the system to trigger a reconnection