### PR TITLE
KM-14792 Pin ios-openssl to exact version 1.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "8ba34f1660f7a248aba66932a6a45915089a3af074a01f073ca7adae1fceb22f",
   "pins" : [
     {
       "identity" : "ios-openssl",
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:pia-foss/ios-openssl.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "ea32980bbd431cd2fd505538093c6258b0972099"
+        "revision" : "e7f9ffdd072fa8709ee25ba8cd2aa5d95f90a6a5",
+        "version" : "1.0.0"
       }
     },
     {
@@ -20,5 +19,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log", from: "1.8.0"),
-        .package(url: "git@github.com:pia-foss/ios-openssl.git", branch: "main")
+        .package(url: "git@github.com:pia-foss/ios-openssl.git", exact: "1.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
- Replaced `branch: "main"` with `exact: "1.0.0"` for the `ios-openssl` dependency in `Package.swift`
- Updated `Package.resolved` to reflect the pinned version

## Test plan
- [ ] Build the project and verify it compiles successfully with the pinned dependency